### PR TITLE
Add resilience tests for bootstrapping logic

### DIFF
--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/ImmediateCloseSocketServer.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/ImmediateCloseSocketServer.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.proxy;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.net.InetAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.net.SocketException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ImmediateCloseSocketServer implements AutoCloseable {
+
+    private final ServerSocket serverSocket;
+    private final ExecutorService serverExecutor;
+    private static final Logger LOGGER = LoggerFactory.getLogger(ImmediateCloseSocketServer.class);
+
+    public ImmediateCloseSocketServer() {
+        try {
+            this.serverSocket = new ServerSocket(0, 50, InetAddress.getLocalHost());
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+        this.serverExecutor = Executors.newSingleThreadExecutor();
+        this.serverExecutor.submit(this::serverLoop);
+    }
+
+    private void serverLoop() {
+        while (!Thread.currentThread().isInterrupted()) {
+            try (Socket clientSocket = this.serverSocket.accept()) {
+                LOGGER.info("Accepted connection from {}, shutting down", clientSocket.getInetAddress());
+            }
+            catch (SocketException e) {
+                break;
+            }
+            catch (Exception e) {
+                LOGGER.error("Unhandled exception, continuing to accept connections", e);
+            }
+        }
+    }
+
+    public String getHostPort() {
+        return this.serverSocket.getInetAddress().getHostName() + ":" + this.serverSocket.getLocalPort();
+    }
+
+    @Override
+    public void close() {
+        this.serverExecutor.shutdownNow();
+        if (!this.serverSocket.isClosed()) {
+            try {
+                this.serverSocket.close();
+            }
+            catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        }
+    }
+
+}

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/ResilienceIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/ResilienceIT.java
@@ -89,8 +89,22 @@ class ResilienceIT extends BaseIT {
     }
 
     @Test
+    void kafkaProducerShouldTolerateKroxyliciousRestartingWithFirstBootstrapUnavailable(Topic randomTopic) throws Exception {
+        try (var immediateCloseServer = new ImmediateCloseSocketServer()) {
+            testProducerCanSurviveARestart(proxy(immediateCloseServer.getHostPort() + "," + cluster.getBootstrapServers()), randomTopic);
+        }
+    }
+
+    @Test
     void kafkaConsumerShouldTolerateKroxyliciousRestarting(Topic randomTopic) throws Exception {
         testConsumerCanSurviveKroxyliciousRestart(proxy(cluster), randomTopic);
+    }
+
+    @Test
+    void kafkaConsumerShouldTolerateKroxyliciousRestartingWithFirstBootstrapUnavailable(Topic randomTopic) throws Exception {
+        try (var immediateCloseServer = new ImmediateCloseSocketServer()) {
+            testConsumerCanSurviveKroxyliciousRestart(proxy(immediateCloseServer.getHostPort() + "," + cluster.getBootstrapServers()), randomTopic);
+        }
     }
 
     @Test


### PR DESCRIPTION
Add resilience tests for bootstrapping logic

Adds a couple of further tests, one with a real 3 node cluster where we shutdown the node corresponding to the first bootstrap server.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
